### PR TITLE
buffing Gen 4 Armor with the best of the specialized stats

### DIFF
--- a/Defs/ThingDefs_Combat/SNS_TPOC_Armor_Gen4.xml
+++ b/Defs/ThingDefs_Combat/SNS_TPOC_Armor_Gen4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-
+<!--First Cycle Helmet-->
   <ThingDef Name="FirstCycleHelmetBase" ParentName="ApparelBase">
     <techLevel>Archotech</techLevel>
     <useHitPoints>false</useHitPoints>
@@ -24,6 +24,30 @@
       <Insulation_Cold>10000</Insulation_Cold>
       <Insulation_Heat>10000</Insulation_Heat>
     </statBases>
+    <equippedStatOffsets>
+    <ShootingAccuracyPawn>10</ShootingAccuracyPawn>
+    <AimingDelayFactor>-0.5</AimingDelayFactor>
+    <RangedCooldownFactor>-0.5</RangedCooldownFactor>
+    <MeleeHitChance>0.5</MeleeHitChance>
+    <MeleeDodgeChance>0.25</MeleeDodgeChance>
+    <ToxicResistance>1</ToxicResistance>
+    <PsychicSensitivity>3</PsychicSensitivity>
+    <MentalBreakThreshold>-2</MentalBreakThreshold>
+    <PsychicEntropyRecoveryRate>10</PsychicEntropyRecoveryRate>
+    <PsychicEntropyMax>2000</PsychicEntropyMax>
+    <SubcoreEncodingSpeed>3</SubcoreEncodingSpeed>
+    <MechRepairSpeed>1</MechRepairSpeed>
+    <MechControlGroups>9</MechControlGroups>
+    <MechRemoteShieldEnergy>250</MechRemoteShieldEnergy>
+    <MechBandwidth>60</MechBandwidth>
+    <WorkSpeedGlobalOffsetMech>4</WorkSpeedGlobalOffsetMech>
+    <EatingSpeed>1</EatingSpeed>
+    <FilthRate>-0.5</FilthRate> <!--brainwashes you to clean up after yourself-->
+    <RestFallRateFactor>-0.5</RestFallRateFactor> <!--NO SLEEP TILL BROOKLYN!-->
+    <WorkSpeedGlobal>1</WorkSpeedGlobal>
+    <ButcheryMechanoidEfficiency>1</ButcheryMechanoidEfficiency>
+    <ConstructSuccessChance>1</ConstructSuccessChance>
+    </equippedStatOffsets>
     <thingCategories>
       <li>ApparelArmor</li>
     </thingCategories>
@@ -45,7 +69,7 @@
     </apparel>
     <smeltable>false</smeltable>
   </ThingDef>
-
+<!--First Cycle Armor-->
   <ThingDef ParentName="ApparelBase">
     <defName>SNS_Apparel_FirstCycleArmor</defName>
     <label>Cycle Alpha Armor</label>
@@ -79,7 +103,29 @@
       </li>
     </comps>
     <equippedStatOffsets>
-      <MoveSpeed>20</MoveSpeed> <!-- You can run, you can run, but I'll always catch up. -->
+    <ShootingAccuracyPawn>10</ShootingAccuracyPawn>
+    <AimingDelayFactor>-0.5</AimingDelayFactor>
+    <RangedCooldownFactor>-0.5</RangedCooldownFactor>
+    <MeleeDodgeChance>0.25</MeleeDodgeChance>
+    <MeleeHitChance>0.5</MeleeHitChance>
+    <ToxicResistance>1</ToxicResistance>
+    <MoveSpeed>20</MoveSpeed> <!-- You can run, you can run, but I'll always catch up. -->
+    <MeleeCooldownFactor>-1</MeleeCooldownFactor>
+    <MeleeDamageFactor>1</MeleeDamageFactor>
+    <StaggerDurationFactor>-1</StaggerDurationFactor>
+    <CarryingCapacity>500</CarryingCapacity> <!--Probably doesn't work.-->
+    <PsychicSensitivity>1</PsychicSensitivity>
+    <SubcoreEncodingSpeed>1</SubcoreEncodingSpeed>
+    <MechRepairSpeed>3</MechRepairSpeed>
+    <MechControlGroups>3</MechControlGroups>
+    <MechRemoteShieldEnergy>250</MechRemoteShieldEnergy>
+    <MechBandwidth>20</MechBandwidth>
+    <MechFormingSpeed>4</MechFormingSpeed>
+    <EatingSpeed>1</EatingSpeed>
+    <FilthRate>-1.5</FilthRate>
+    <RestFallRateFactor>-0.5</RestFallRateFactor>
+    <WorkSpeedGlobal>2</WorkSpeedGlobal>
+    <ConstructSuccessChance>1</ConstructSuccessChance>
     </equippedStatOffsets>
     <thingCategories>
       <li>ApparelArmor</li>

--- a/Defs/ThingDefs_Combat/SNS_TPOC_Armor_Gen4.xml
+++ b/Defs/ThingDefs_Combat/SNS_TPOC_Armor_Gen4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <ThingDef Name="FirstCycleHelmetBase" ParentName="ApparelBase" Abstract="True">
+  <ThingDef Name="FirstCycleHelmetBase" ParentName="ApparelBase">
     <techLevel>Archotech</techLevel>
     <useHitPoints>false</useHitPoints>
     <graphicData>
@@ -9,6 +9,9 @@
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <uiIconScale>1.25</uiIconScale>
+    <defName>SNS_Apparel_FirstCycleHelmet</defName>
+    <label>Cycle Alpha Helmet</label>
+    <description>A wondrous helmet with a beautiful holographic halo floating atop the wearer's head. The helmet creates a temporal field around the user's head, protecting them from all incoming fire, and even the vacuum of deep space. Those fortunate enough to survive an combat encounter with one of its bearers, describe an invincible angel wreaking divine retribution on the battlefield.</description>
     <statBases>
       <MaxHitPoints>9999</MaxHitPoints>
       <MarketValue>50000000</MarketValue> <!-- value so high to ensure nobody spawns with it -->
@@ -41,12 +44,6 @@
       <careIfWornByCorpse>false</careIfWornByCorpse>
     </apparel>
     <smeltable>false</smeltable>
-  </ThingDef>
-
-  <ThingDef ParentName="FirstCycleHelmetBase">
-    <defName>SNS_Apparel_FirstCycleHelmet</defName>
-    <label>Cycle Alpha Helmet</label>
-    <description>A wondrous helmet with a beautiful holographic halo floating atop the wearer's head. The helmet creates a temporal field around the user's head, protecting them from all incoming fire, and even the vacuum of deep space. Those fortunate enough to survive an combat encounter with one of its bearers, describe an invincible angel wreaking divine retribution on the battlefield.</description>
   </ThingDef>
 
   <ThingDef ParentName="ApparelBase">


### PR DESCRIPTION
-moved the helmet defName out of an unnecessary parentName thingy. there was no other use of the FirstCycleHelmetBase parent def, so i consolidated it.

-added the best of the specialized stats to the cycle alpha armor, multiplied by two. the exceptions for the multiplication are melee dodge, because never getting hit is boring, and tox resistance, because it's not needed.

This one is honestly just all buff, but it seems appropriate since Gen4 is supposed to be OP.